### PR TITLE
Update BinanceAPI Constructor and add API calls

### DIFF
--- a/src/BinanceAPI.php
+++ b/src/BinanceAPI.php
@@ -66,14 +66,11 @@ class BinanceAPI
     //------ PUBLIC API CALLS --------
     /*
     * getServerTime
+    * getExchangeInfo
+    * getMarkets
     * getTicker
     * getCurrencies
     * getMarkets
-    *
-    *
-    *
-    *
-    *
     */
 
 
@@ -88,7 +85,32 @@ class BinanceAPI
         $return = $this->request('v1/time');
         return $return['serverTime'];
     }
-    
+
+
+    /**
+     * Current exchange trading rules and symbol information
+     *
+     * @return mixed
+     * @throws \Exception
+     */
+    public function getExchangeInfo()
+    {
+        return $this->request('v1/exchangeInfo');
+    }
+
+
+    /**
+     * Symbol information via exchangeInfo
+     *
+     * @return mixed
+     * @throws \Exception
+     */
+    public function getMarkets()
+    {
+        $return = $this->request('v1/exchangeInfo');
+        return $return['symbols'];
+    }
+
 
     /**
      * Get ticker
@@ -100,6 +122,7 @@ class BinanceAPI
     {
         return $this->request('v1/ticker/allPrices');
     }
+    
 
     /**
      * Get ticker
@@ -121,19 +144,6 @@ class BinanceAPI
        //Seems to be no such functionality
        return false;
     }
-
-    /**
-     * Current exchange trading rules and symbol information
-     *
-     * @return mixed
-     * @throws \Exception
-     */
-    public function getMarkets()
-    {
-        $return = $this->request('v1/exchangeInfo');
-        return $return['symbols'];
-    }
-
 
 
     //------ PRIVATE API CALLS ----------

--- a/src/BinanceAPI.php
+++ b/src/BinanceAPI.php
@@ -13,17 +13,23 @@ class BinanceAPI
     /**
      * Constructor for BinanceAPI
      */
-    function __construct()
+    function __construct(array $auth = null, array $urls = null, array $settings = null)
     {
-        $this->key        = config('binance.auth.key');
-        $this->secret     = config('binance.auth.secret');
-        $this->url        = config('binance.urls.api');
-        $this->wapi_url   = config('binance.urls.wapi');
-        $this->recvWindow = config('binance.settings.timing');
+        if(!$auth)      $auth       = config("binance.auth");
+        if(!$urls)      $urls       = config("binance.urls");
+        if(!$settings)  $settings   = config("binance.settings");
+
+        $this->key    = array_get($auth, 'key');
+        $this->secret = array_get($auth, 'secret');
+
+        $this->url        = array_get($urls, 'api');
+        $this->wapi_url   = array_get($urls, 'wapi');
+
+        $this->recvWindow = array_get($settings, 'timing');
         $this->curl       = curl_init();
 
         $curl_options     = [
-            CURLOPT_SSL_VERIFYPEER => config('binance.settings.ssl'),
+            CURLOPT_SSL_VERIFYPEER => array_get($settings, 'ssl'),
             CURLOPT_SSL_VERIFYHOST => 2,
             CURLOPT_USERAGENT      => 'Binance PHP API Agent',
             CURLOPT_RETURNTRANSFER => true,
@@ -32,7 +38,7 @@ class BinanceAPI
         ];
 
         curl_setopt_array($this->curl, $curl_options);
-        
+
     }
 
     /**

--- a/src/BinanceAPI.php
+++ b/src/BinanceAPI.php
@@ -65,15 +65,16 @@ class BinanceAPI
 
     //------ PUBLIC API CALLS --------
     /*
-    * getServerTime
-    * getExchangeInfo
-    * getMarkets
-    * getTickers
-    * getOrderBook
-    * getPublicTrades
-    * getAggTrades
-    * getCandlesticks
-    */
+     * getServerTime
+     * getExchangeInfo
+     * getMarkets
+     * getTickers
+     * getOrderBook
+     * getPublicTrades
+     * getAggTrades
+     * getCandlesticks
+     * getAvgPrice
+     */
 
 
     /**
@@ -239,6 +240,24 @@ class BinanceAPI
         ];
 
         return $this->request('v1/klines', $data);
+    }
+
+
+    /**
+     * Current average price
+     * Current average price for a symbol.
+     *
+     * @param string $symbol
+     * @return mixed
+     * @throws \Exception
+     */
+    public function getAvgPrice($symbol = 'BNBBTC')
+    {
+        $data = [
+            'symbol' => $symbol,
+        ];
+
+        return $this->request('v3/avgPrice', $data);
     }
 
 

--- a/src/BinanceAPI.php
+++ b/src/BinanceAPI.php
@@ -123,13 +123,6 @@ class BinanceAPI
     }
 
 
-    public function getCurrencies()
-    {
-       //Seems to be no such functionality
-       return false;
-    }
-
-
     //------ PRIVATE API CALLS ----------
     /*
     * getBalances

--- a/src/BinanceAPI.php
+++ b/src/BinanceAPI.php
@@ -75,6 +75,7 @@ class BinanceAPI
      * getCandlesticks
      * getAvgPrice
      * getTickerChange
+     * getTickerPrice
      */
 
 
@@ -278,6 +279,24 @@ class BinanceAPI
         ];
 
         return $this->request('v1/ticker/24hr', $data);
+    }
+
+
+    /**
+     * Symbol price ticker
+     * Latest price for a symbol or symbols.
+     *
+     * @param string $symbol
+     * @return mixed
+     * @throws \Exception
+     */
+    public function getTickerPrice($symbol = null)
+    {
+        $data = [
+            'symbol' => $symbol,
+        ];
+
+        return $this->request('v3/ticker/price', $data);
     }
 
 

--- a/src/BinanceAPI.php
+++ b/src/BinanceAPI.php
@@ -71,6 +71,7 @@ class BinanceAPI
     * getTickers
     * getOrderBook
     * getPublicTrades
+    * getAggTrades
     */
 
 
@@ -160,6 +161,41 @@ class BinanceAPI
         ];
 
         return $this->request('v1/trades', $data);
+    }
+
+
+    /**
+     * Compressed/Aggregate trades list
+     * Get compressed, aggregate trades. Trades that fill at the time, from the same order, with the same price will have the quantity aggregated.
+     *
+     * "a": 26129,         // Aggregate tradeId
+     * "p": "0.01633102",  // Price
+     * "q": "4.70443515",  // Quantity
+     * "f": 27781,         // First tradeId
+     * "l": 27781,         // Last tradeId
+     * "T": 1498793709153, // Timestamp
+     * "m": true,          // Was the buyer the maker?
+     * "M": true           // Was the trade the best price match?
+     *
+     * @param string $symbol
+     * @param int $fromId
+     * @param timestamp $startTime
+     * @param timestamp $endTime
+     * @param int $limit Default 500; max 1000.
+     * @return mixed
+     * @throws \Exception
+     */
+    public function getAggTrades($symbol = 'BNBBTC', $fromId = null, $startTime = null, $endTime = null, $limit = 500)
+    {
+        $data = [
+            'symbol' => $symbol,
+            'fromId' => $fromId,
+            'startTime' => $startTime,
+            'endTime' => $endTime,
+            'limit'  => $limit,
+        ];
+
+        return $this->request('v1/aggTrades', $data);
     }
 
 

--- a/src/BinanceAPI.php
+++ b/src/BinanceAPI.php
@@ -70,6 +70,7 @@ class BinanceAPI
     * getMarkets
     * getTickers
     * getOrderBook
+    * getPublicTrades
     */
 
 
@@ -139,6 +140,26 @@ class BinanceAPI
         ];
 
         return $this->request('v1/depth', $data);
+    }
+
+
+    /**
+     * Recent trades
+     * Get recent trades (up to last 500).
+     *
+     * @param string $symbol
+     * @param int $limit Default 500; max 1000.
+     * @return mixed
+     * @throws \Exception
+     */
+    public function getPublicTrades($symbol = 'BNBBTC', $limit = 500)
+    {
+        $data = [
+            'symbol' => $symbol,
+            'limit'  => $limit,
+        ];
+
+        return $this->request('v1/trades', $data);
     }
 
 

--- a/src/BinanceAPI.php
+++ b/src/BinanceAPI.php
@@ -70,7 +70,6 @@ class BinanceAPI
     * getMarkets
     * getTicker
     * getCurrencies
-    * getMarkets
     */
 
 
@@ -121,21 +120,6 @@ class BinanceAPI
     public function getTickers()
     {
         return $this->request('v1/ticker/allPrices');
-    }
-    
-
-    /**
-     * Get ticker
-     *
-     * @return mixed
-     * @throws \Exception
-     */
-    public function getTicker($symbol)
-    {
-         $data = [
-            'symbol' => $symbol
-        ];
-        return $this->request('v1/ticker/allPrices', $data);
     }
 
 

--- a/src/BinanceAPI.php
+++ b/src/BinanceAPI.php
@@ -72,6 +72,7 @@ class BinanceAPI
     * getOrderBook
     * getPublicTrades
     * getAggTrades
+    * getCandlesticks
     */
 
 
@@ -196,6 +197,48 @@ class BinanceAPI
         ];
 
         return $this->request('v1/aggTrades', $data);
+    }
+
+
+    /**
+     * Kline/Candlestick data
+     * Kline/candlestick bars for a symbol. Klines are uniquely identified by their open time.
+     *
+     * candlesticks get the candles for the given intervals
+     * 1m,3m,5m,15m,30m,1h,2h,4h,6h,8h,12h,1d,3d,1w,1M
+     *
+     * 1499040000000,      // Open time
+     * "0.01634790",       // Open
+     * "0.80000000",       // High
+     * "0.01575800",       // Low
+     * "0.01577100",       // Close
+     * "148976.11427815",  // Volume
+     * 1499644799999,      // Close time
+     * "2434.19055334",    // Quote asset volume
+     * 308,                // Number of trades
+     * "1756.87402397",    // Taker buy base asset volume
+     * "28.46694368",      // Taker buy quote asset volume
+     * "17928899.62484339" // Ignore.
+     *
+     * @param string $symbol
+     * @param string $interval
+     * @param timestamp $startTime
+     * @param timestamp $endTime
+     * @param int $limit Default 500; max 1000.
+     * @return mixed
+     * @throws \Exception
+     */
+    public function getCandlesticks($symbol = 'BNBBTC', $interval = '1h', $startTime = null, $endTime = null, $limit = 500)
+    {
+        $data = [
+            'symbol' => $symbol,
+            'interval' => $interval,
+            'startTime' => $startTime,
+            'endTime' => $endTime,
+            'limit'  => $limit,
+        ];
+
+        return $this->request('v1/klines', $data);
     }
 
 

--- a/src/BinanceAPI.php
+++ b/src/BinanceAPI.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 namespace adman9000\binance;
 
 class BinanceAPI
@@ -68,8 +68,8 @@ class BinanceAPI
     * getServerTime
     * getExchangeInfo
     * getMarkets
-    * getTicker
-    * getCurrencies
+    * getTickers
+    * getOrderBook
     */
 
 
@@ -120,6 +120,25 @@ class BinanceAPI
     public function getTickers()
     {
         return $this->request('v1/ticker/allPrices');
+    }
+
+
+    /**
+     * Order book
+     *
+     * @param string $symbol
+     * @param int $limit default 100; max 1000; Valid limits:[5, 10, 20, 50, 100, 500, 1000]
+     * @return mixed
+     * @throws \Exception
+     */
+    public function getOrderBook($symbol = 'BNBBTC', $limit = 100)
+    {
+        $data = [
+            'symbol' => $symbol,
+            'limit'  => $limit,
+        ];
+
+        return $this->request('v1/depth', $data);
     }
 
 
@@ -215,7 +234,7 @@ class BinanceAPI
         }
 
         $b = $this->privateRequest('v3/order', $data, 'POST');
-    
+
         return $b;
     }
 
@@ -283,7 +302,7 @@ class BinanceAPI
     public function depositAddress($symbol) {
 
         return $this->wapiRequest("v3/depositAddress.html", ['asset' => $symbol]);
-        
+
     }
 
     //------ REQUESTS FUNCTIONS ------
@@ -299,8 +318,17 @@ class BinanceAPI
      */
     private function request($url, $params = [], $method = 'GET')
     {
-        // Set URL & Header
-        curl_setopt($this->curl, CURLOPT_URL, $this->url . $url);
+        if($params)
+        {
+            $query   = http_build_query($params, '', '&');
+            // Set URL & Header
+            curl_setopt($this->curl, CURLOPT_URL, $this->url . $url . "?{$query}");
+
+        } else {
+            // Set URL & Header
+            curl_setopt($this->curl, CURLOPT_URL, $this->url . $url);
+        }
+
         curl_setopt($this->curl, CURLOPT_HTTPHEADER, array());
 
         //Add post vars
@@ -351,7 +379,7 @@ class BinanceAPI
 
         // make request
         curl_setopt($this->curl, CURLOPT_HTTPHEADER, $headers);
-   
+
          // build the POST data string
         $postdata = $params;
 
@@ -404,7 +432,7 @@ class BinanceAPI
 
         // make request
         curl_setopt($this->curl, CURLOPT_HTTPHEADER, $headers);
-   
+
          // build the POST data string
         $postdata = $params;
 

--- a/src/BinanceAPI.php
+++ b/src/BinanceAPI.php
@@ -76,6 +76,7 @@ class BinanceAPI
      * getAvgPrice
      * getTickerChange
      * getTickerPrice
+     * getBookTicker
      */
 
 
@@ -297,6 +298,24 @@ class BinanceAPI
         ];
 
         return $this->request('v3/ticker/price', $data);
+    }
+
+
+    /**
+     * Symbol order book ticker
+     * Best price/qty on the order book for a symbol or symbols.
+     *
+     * @param string $symbol
+     * @return mixed
+     * @throws \Exception
+     */
+    public function getBookTicker($symbol = null)
+    {
+        $data = [
+            'symbol' => $symbol,
+        ];
+
+        return $this->request('v3/ticker/bookTicker', $data);
     }
 
 

--- a/src/BinanceAPI.php
+++ b/src/BinanceAPI.php
@@ -74,6 +74,7 @@ class BinanceAPI
      * getAggTrades
      * getCandlesticks
      * getAvgPrice
+     * getTickerChange
      */
 
 
@@ -258,6 +259,25 @@ class BinanceAPI
         ];
 
         return $this->request('v3/avgPrice', $data);
+    }
+
+
+    /**
+     * 24hr ticker price change statistics
+     * 24 hour rolling window price change statistics. Careful when accessing this with no symbol.
+     * Weight: 1 for a single symbol; 40 when the symbol parameter is omitted
+     *
+     * @param string $symbol
+     * @return mixed
+     * @throws \Exception
+     */
+    public function getTickerChange($symbol = null)
+    {
+        $data = [
+            'symbol' => $symbol,
+        ];
+
+        return $this->request('v1/ticker/24hr', $data);
     }
 
 

--- a/src/BinanceAPI.php
+++ b/src/BinanceAPI.php
@@ -65,6 +65,7 @@ class BinanceAPI
 
     //------ PUBLIC API CALLS --------
     /*
+    * getServerTime
     * getTicker
     * getCurrencies
     * getMarkets
@@ -74,6 +75,20 @@ class BinanceAPI
     *
     *
     */
+
+
+    /**
+     * Test connectivity to the Rest API and get the current server time.
+     *
+     * @return timestamp
+     * @throws \Exception
+     */
+    public function getServerTime()
+    {
+        $return = $this->request('v1/time');
+        return $return['serverTime'];
+    }
+    
 
     /**
      * Get ticker


### PR DESCRIPTION
Setup the `__construct()` so that you can call `BinanceAPI` outside of the alias/facade.  Similar to what you have setup on your [laravel-bittrex package](https://github.com/adman9000/laravel-bittrex/blob/master/src/BittrexAPI.php#L23)

```php
function __construct(array $auth = null, array $urls = null, array $settings = null)
    {
        if(!$auth)      $auth       = config("binance.auth");
        if(!$urls)      $urls       = config("binance.urls");
        if(!$settings)  $settings   = config("binance.settings");

        $this->key    = array_get($auth, 'key');
        $this->secret = array_get($auth, 'secret');

        $this->url        = array_get($urls, 'api');
        $this->wapi_url   = array_get($urls, 'wapi');

        $this->recvWindow = array_get($settings, 'timing');
        $this->curl       = curl_init();

        $curl_options     = [
            CURLOPT_SSL_VERIFYPEER => array_get($settings, 'ssl'),
            CURLOPT_SSL_VERIFYHOST => 2,
            CURLOPT_USERAGENT      => 'Binance PHP API Agent',
            CURLOPT_RETURNTRANSFER => true,
            CURLOPT_CONNECTTIMEOUT => 20,
            CURLOPT_TIMEOUT => 300
        ];

        curl_setopt_array($this->curl, $curl_options);

    }
```

I added more public API calls based on these docs: https://github.com/binance-exchange/binance-official-api-docs/blob/master/rest-api.md

**Interestingly enough, `v1/ticker/allPrices` isn't mentioned ANYWHERE but it is a valid call with your `getTickers()` method.**

New methods include: 
* getServerTime
* getExchangeInfo
* getOrderBook
* getPublicTrades
* getAggTrades
* getCandlesticks
* getAvgPrice
* getTickerChange
* getTickerPrice
* getBookTicker

I removed `getTicker()` because it returned the exact same information as `getTickers()`.  I also removed `getCurrencies()` because there was no need for it.