### PR TITLE
Replaced request exception with Laravel log facade

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Utilises autoloading in Laravel 5.5+. For older versions add the following lines
 
 #### Publish config
 
+Create a configurable config file:
+
 ```
 php artisan vendor:publish --provider="adman9000\binance\BinanceServiceProvider"
 ```

--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ Utilises autoloading in Laravel 5.5+. For older versions add the following lines
     ],
 ```
 
+#### Publish config
+
+```
+php artisan vendor:publish --provider="adman9000\binance\BinanceServiceProvider"
+```
+
 ## Features
 
 Price tickers, balances, trades

--- a/config/binance.php
+++ b/config/binance.php
@@ -40,7 +40,9 @@ return [
 
     'settings' => [
         'timing' => env('BINANCE_TIMING', 5000),
-        'ssl'    => env('BINANCE_SSL_VERIFYPEER', true)
+        'ssl'    => env('BINANCE_SSL_VERIFYPEER', true),
+        'connectiontimeout' => env('BINANCE_SETTINGS_CONNECTIONTIMEOUT', 20),
+        'timeout' => env('BINANCE_SETTINGS_TIMEOUT', 300)
     ],
 
 ];

--- a/src/BinanceAPI.php
+++ b/src/BinanceAPI.php
@@ -29,8 +29,8 @@ class BinanceAPI
             CURLOPT_SSL_VERIFYHOST => 2,
             CURLOPT_USERAGENT      => 'Binance PHP API Agent',
             CURLOPT_RETURNTRANSFER => true,
-            CURLOPT_CONNECTTIMEOUT => 20,
-            CURLOPT_TIMEOUT => 300
+            CURLOPT_CONNECTTIMEOUT => config('binance.settings.connectiontimeout'),
+            CURLOPT_TIMEOUT => config('binance.settings.timeout')
         ];
 
         curl_setopt_array($this->curl, $curl_options);

--- a/src/BinanceAPI.php
+++ b/src/BinanceAPI.php
@@ -1,6 +1,8 @@
 <?php 
 namespace adman9000\binance;
 
+use Log;
+
 class BinanceAPI
 {
     protected $key;         // API key
@@ -304,14 +306,14 @@ class BinanceAPI
 
         //Get result
         $result = curl_exec($this->curl);
-        if($result === false)
-            throw new \Exception('CURL error: ' . curl_error($this->curl));
-
-        // decode results
-        $result = json_decode($result, true);
-
-        if(!is_array($result) || json_last_error())
-            throw new \Exception('JSON decode error');
+        if($result === false) {
+            Log::Error('BinanceAPI: CURL not completed. No network? Error: '.curl_error($this->curl));
+        } else {
+            // decode results
+            $result = json_decode($result, true);
+            if(!is_array($result) || json_last_error())
+                Log::Error('BinanceAPI: JSON decode error in Binance API');
+        }
 
         return $result;
 
@@ -358,13 +360,14 @@ class BinanceAPI
 
         //Get result
         $result = curl_exec($this->curl);
-        if($result === false)
-            throw new \Exception('CURL error: ' . curl_error($this->curl));
-
-         // decode results
-        $result = json_decode($result, true);
-        if(!is_array($result) || json_last_error())
-            throw new \Exception('JSON decode error');
+        if($result === false) {
+            Log::Error('BinanceAPI: CURL not completed. No network? Error: '.curl_error($this->curl));
+        } else {
+            // decode results
+            $result = json_decode($result, true);
+            if(!is_array($result) || json_last_error())
+                Log::Error('BinanceAPI: JSON decode error in Binance API');
+        }
 
         return $result;
 
@@ -411,13 +414,14 @@ class BinanceAPI
 
         //Get result
         $result = curl_exec($this->curl);
-        if($result === false)
-            throw new \Exception('CURL error: ' . curl_error($this->curl));
-
-         // decode results
-        $result = json_decode($result, true);
-        if(!is_array($result) || json_last_error())
-            throw new \Exception('JSON decode error');
+        if($result === false) {
+            Log::Error('BinanceAPI: CURL not completed. No network? Error: '.curl_error($this->curl));
+        } else {
+            // decode results
+            $result = json_decode($result, true);
+            if(!is_array($result) || json_last_error())
+                Log::Error('BinanceAPI: JSON decode error in Binance API');
+        }
 
         return $result;
 

--- a/src/BinanceAPI.php
+++ b/src/BinanceAPI.php
@@ -1,8 +1,6 @@
 <?php 
 namespace adman9000\binance;
 
-use Log;
-
 class BinanceAPI
 {
     protected $key;         // API key
@@ -306,14 +304,13 @@ class BinanceAPI
 
         //Get result
         $result = curl_exec($this->curl);
-        if($result === false) {
-            Log::Error('BinanceAPI: CURL not completed. No network? Error: '.curl_error($this->curl));
-        } else {
-            // decode results
-            $result = json_decode($result, true);
-            if(!is_array($result) || json_last_error())
-                Log::Error('BinanceAPI: JSON decode error in Binance API');
-        }
+        if($result === false)
+            return null;
+
+        // decode results
+        $result = json_decode($result, true);
+        if(!is_array($result) || json_last_error())
+            return null;
 
         return $result;
 
@@ -360,14 +357,13 @@ class BinanceAPI
 
         //Get result
         $result = curl_exec($this->curl);
-        if($result === false) {
-            Log::Error('BinanceAPI: CURL not completed. No network? Error: '.curl_error($this->curl));
-        } else {
-            // decode results
-            $result = json_decode($result, true);
-            if(!is_array($result) || json_last_error())
-                Log::Error('BinanceAPI: JSON decode error in Binance API');
-        }
+        if($result === false)
+            return null;
+
+        // decode results
+        $result = json_decode($result, true);
+        if(!is_array($result) || json_last_error())
+            return null;
 
         return $result;
 
@@ -414,14 +410,13 @@ class BinanceAPI
 
         //Get result
         $result = curl_exec($this->curl);
-        if($result === false) {
-            Log::Error('BinanceAPI: CURL not completed. No network? Error: '.curl_error($this->curl));
-        } else {
-            // decode results
-            $result = json_decode($result, true);
-            if(!is_array($result) || json_last_error())
-                Log::Error('BinanceAPI: JSON decode error in Binance API');
-        }
+        if($result === false)
+            return null;
+
+        // decode results
+        $result = json_decode($result, true);
+        if(!is_array($result) || json_last_error())
+            return null;
 
         return $result;
 


### PR DESCRIPTION
In case there is a network outage or Binance restarts its API this Laravel-Binance package will throw an exception and kill any running script that call's this BinanceAPI.php. This is annoying when you call this script from a backend looping script to get the tickers every second.

I am not sure if I did it right but I got rid of the exception and script quits. The exception error message is thrown in the Laravel Log.

Maybe there is a better solution but just throw an exception and stop the script is not a nice thing.